### PR TITLE
WIP: optional new liquid behavior

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -148,7 +148,7 @@ local function preprocess_node(nodedef)
 	end
 
 	-- Flowing liquid uses param2
-	if nodedef.liquidtype == "flowing" then
+	if nodedef.liquidtype == "flowing" and nodedef.paramtype2 ~= "directionalflowing" then
 		nodedef.paramtype2 = "flowingliquid"
 	end
 end

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -2,6 +2,10 @@ local builtin_shared = ...
 local S = core.get_translator("__builtin")
 local debug_getinfo = debug.getinfo
 
+local force_directional_liquids = core.settings:get_bool("force_directional_liquids", false)
+local force_liquid_range = tonumber(core.settings:get("force_liquid_range")) or -1
+local force_liquid_directed_range = tonumber(core.settings:get("force_liquid_directed_range")) or -1
+
 --
 -- Make raw registration functions inaccessible to anyone except this file
 --
@@ -147,9 +151,18 @@ local function preprocess_node(nodedef)
 			" limiting it: " .. nodedef.name)
 	end
 
-	-- Flowing liquid uses param2
+	-- Override some properties for liquids
 	if nodedef.liquidtype == "flowing" and nodedef.paramtype2 ~= "directionalflowing" then
-		nodedef.paramtype2 = "flowingliquid"
+		nodedef.paramtype2 = force_directional_liquids and "directionalflowing" or "flowingliquid"
+	end
+	if nodedef.liquidtype == "source" and nodedef.paramtype2 ~= "directionalsource" then
+		nodedef.paramtype2 = force_directional_liquids and "directionalsource" or nil
+	end
+	if nodedef.liquidtype and force_liquid_range ~= -1 then
+		nodedef.liquid_range = force_liquid_range
+	end
+	if nodedef.liquidtype and force_liquid_directed_range ~= -1 then
+		nodedef.liquid_directed_range = force_liquid_directed_range
 	end
 end
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1166,6 +1166,18 @@ movement_liquid_sink (Liquid sinking) float 10.0
 #    Acceleration of gravity, in nodes per second per second.
 movement_gravity (Gravity) float 9.81
 
+#    Force liquid_range property of all liquids. 0-8 sets range, -1 keeps
+#    game/mode provided range.
+force_liquid_range (Force all liquids to this range) int -1 -1 8
+
+#    Force paramtype2 of liquid sources to directionalsource and flows to
+#    directionalflowing.
+force_directional_liquids (Force all liquids to be directional) bool false
+
+#    Force liquid_directed_range property of all liquids. 0-7 sets range, -1
+#    keeps game/mode provided range.
+force_liquid_directed_range (Force all liquids to this directed range) int -1 -1 7
+
 
 [Mapgen] [world_creation]
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1376,12 +1376,42 @@ The function of `param2` is determined by `paramtype2` in node definition.
 `param2` is reserved for the engine when `paramtype2 != "none"`.
 
 * `paramtype2 = "flowingliquid"`
-    * Used by `drawtype = "flowingliquid"` and `liquidtype = "flowing"`
+    * Automatically Used by `drawtype = "flowingliquid"` and `liquidtype = "flowing"`
+      if none set
     * The liquid level and a flag of the liquid are stored in `param2`
     * Bits 0-2: Liquid level (0-7). The higher, the more liquid is in this node;
       see `core.get_node_level`, `core.set_node_level` and `core.add_node_level`
       to access/manipulate the content of this field
     * Bit 3: If set, liquid is flowing downwards (no graphical effect)
+* `paramtype2 = "directionalflowing"`
+    * Alternative implementation of a flowing liquid with the option to not
+      spread out, but flow in a single direction towards a lower level
+    * The liquid level and direction of the liquid are stored in `param2`
+    * Bits 0-2: Liquid level (0-7). The higher, the more liquid is in this node;
+      see `minetest.get_node_level`, `minetest.set_node_level` and `minetest.add_node_level`
+      to access/manipulate the content of this field
+    * Bit 3-7: direction and distance to closest flowdown; 0: no direction,
+      31: flowing down,
+      1-4: flowing only in +Z/+X/-Z/-X direction, directly into a flowdown
+      5-28: flowing in the direction given by (d-1)%4+1 with the closest
+            flowdown floor((d-1)/4)+1 steps away, supporting distances 0-6
+      29-30 unused
+    * directional liquid has the following differences from normal liquids
+        * optionally flowing in a single direction if there is a path within
+          liquid_directed_range to a lower level
+        * when two or more different liquids meet in a node the strongest flow
+          will displace the other liquids
+        * a liquid source node that flows down will not create horizontal flows
+        * flowing liquid above a source node of the same kind will not spread
+          horizontally
+        * rendering is slightly different; older clients will render linear
+          flows without volume, but otherwise work fine
+* `paramtype2 = "directionalsource"`
+    * Alternative implementation of a liquid source with the option to not
+      spread out, but flow in a single direction towards a lower level
+    * Bit 3-7: direction to closest flowdown; 0: no direction, 31: flowing down,
+      1-4: flowing only in +Z/+X/-Z/-X direction, directly into a flowdown
+      5-30 unused, distance to flowdown is not encoded
 * `paramtype2 = "wallmounted"`
     * Supported drawtypes: "torchlike", "signlike", "plantlike",
       "plantlike_rooted", "normal", "nodebox", "mesh"
@@ -10302,6 +10332,12 @@ Used by `core.register_node`.
     -- Maximum distance that flowing liquid nodes can spread around
     -- source on flat land;
     -- maximum = 8; set to 0 to disable liquid flow
+
+    liquid_directed_range = 8,
+    -- Only for "directionalflowing" paramtype2
+    -- Maximum length of a directional path on flat land
+    -- maximum = 7; set to 0 to disable directional liquid flow
+       (currently does not affect paramtype2 "directionalsource")
 
     drowning = 0,
     -- Player will take this amount of damage if no bubbles are left

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -617,11 +617,12 @@ void MapblockMeshGenerator::getLiquidNeighborhood()
 			else
 				liquid_level -= (LIQUID_LEVEL_MAX + 1 - range);
 			neighbor.level = (-0.5f + (liquid_level + 0.5f) / range);
-		}
+		} else if (cur_node.f->param_type_2 == CPT2_DIRECTIONAL_FLOWING)
+			continue;
 
 		// Check node above neighbor.
 		// NOTE: This doesn't get executed if neighbor
-		//       doesn't exist
+		//       isn't a liquid
 		p2.Y++;
 		n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
 		if (n2.getContent() == cur_liquid.c_source || n2.getContent() == cur_liquid.c_flowing)

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -601,6 +601,7 @@ void MapblockMeshGenerator::getLiquidNeighborhood()
 		neighbor.content = n2.getContent();
 		neighbor.level = -0.5f;
 		neighbor.is_same_liquid = false;
+		neighbor.is_flowing_down = false;
 		neighbor.top_is_same_liquid = false;
 
 		if (neighbor.content == CONTENT_IGNORE)
@@ -611,6 +612,12 @@ void MapblockMeshGenerator::getLiquidNeighborhood()
 			neighbor.level = 0.5f;
 		} else if (neighbor.content == cur_liquid.c_flowing) {
 			neighbor.is_same_liquid = true;
+                        if (cur_node.f->param_type_2 == CPT2_DIRECTIONAL_FLOWING)
+                          neighbor.is_flowing_down =
+                            ((n2.param2 & LIQUID_DIRECTION_MASK) == LIQUID_DIRECTION_MASK);
+                        else
+                          neighbor.is_flowing_down =
+                            ((n2.param2 & LIQUID_FLOW_DOWN_MASK) == LIQUID_FLOW_DOWN_MASK);
 			u8 liquid_level = (n2.param2 & LIQUID_LEVEL_MASK);
 			if (liquid_level <= LIQUID_LEVEL_MAX + 1 - range)
 				liquid_level = 0;
@@ -647,8 +654,10 @@ f32 MapblockMeshGenerator::getCornerLevel(int i, int k) const
 		const LiquidData::NeighborData &neighbor_data = cur_liquid.neighbors[k + dk][i + di];
 		content_t content = neighbor_data.content;
 
-		// If top is liquid, draw starting from top of node
-		if (neighbor_data.top_is_same_liquid)
+		// If top is liquid, draw starting from top of node unless
+                // liquid is directional and neighbor is flowing down
+		if ((cur_node.f->param_type_2 == CPT2_FLOWINGLIQUID || !neighbor_data.is_flowing_down) &&
+				neighbor_data.top_is_same_liquid)
 			return 0.5f;
 
 		// Source always has the full height
@@ -657,6 +666,10 @@ f32 MapblockMeshGenerator::getCornerLevel(int i, int k) const
 
 		// Flowing liquid has level information
 		if (content == cur_liquid.c_flowing) {
+			if (cur_node.f->param_type_2 == CPT2_DIRECTIONAL_FLOWING &&
+					neighbor_data.is_flowing_down && neighbor_data.top_is_same_liquid)
+				// directional liquid flowing into a waterfall
+				return -0.4f;
 			sum += neighbor_data.level;
 			count++;
 		} else if (content == CONTENT_AIR) {

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -663,7 +663,11 @@ f32 MapblockMeshGenerator::getCornerLevel(int i, int k) const
 			air_count++;
 		}
 	}
-	if (air_count >= 2)
+	if (air_count >= (cur_node.f->param_type_2 == CPT2_DIRECTIONAL_FLOWING ? 3 : 2))
+		// visualize flow turning into air; require 2 air nodes for
+		// backwards compatibility, 3 for directional flows (which would
+		// work fine for classic liquids too)
+		// TODO: decide whether to use 3 air nodes for all liquids
 		return -0.5f + 0.2f / BS;
 	if (count > 0)
 		return sum / count;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -440,26 +440,32 @@ void MapblockMeshGenerator::drawSolidNode()
 	};
 	TileSpec tiles[6];
 	u16 lights[6];
+	bool draw_directional_liquid_top = false;
 	content_t n1 = cur_node.n.getContent();
 	for (int face = 0; face < 6; face++) {
 		v3s16 p2 = blockpos_nodes + cur_node.p + tile_dirs[face];
 		MapNode neighbor = data->m_vmanip.getNodeNoEx(p2);
 		content_t n2 = neighbor.getContent();
 		bool backface_culling = cur_node.f->drawtype == NDT_NORMAL;
+		bool directional_source_top = (cur_node.f->param_type_2 == CPT2_DIRECTIONAL_SOURCE
+				&& face == 0);
 		if (n2 == n1)
 			continue;
 		if (n2 == CONTENT_IGNORE)
 			continue;
 		if (n2 != CONTENT_AIR) {
 			const ContentFeatures &f2 = nodedef->get(n2);
-			if (f2.visuals->solidness == 2)
+			if (!directional_source_top && f2.visuals->solidness == 2)
 				continue;
 			if (cur_node.f->drawtype == NDT_LIQUID) {
 				if (cur_node.f->sameLiquidRender(f2))
 					continue;
-				backface_culling = f2.visuals->solidness || f2.visuals->visual_solidness;
+				if (!directional_source_top)
+					backface_culling = f2.visuals->solidness || f2.visuals->visual_solidness;
 			}
 		}
+		if (directional_source_top)
+			draw_directional_liquid_top = true;
 		faces |= 1 << face;
 		getTile(tile_dirs[face], &tiles[face]);
 		for (auto &layer : tiles[face].layers) {
@@ -474,6 +480,9 @@ void MapblockMeshGenerator::drawSolidNode()
 		return;
 	u8 mask = faces ^ 0b0011'1111; // k-th bit is set if k-th face is to be *omitted*, as expected by cuboid drawing functions.
 	auto box = aabb3f(v3f(-0.5 * BS), v3f(0.5 * BS));
+	if (draw_directional_liquid_top)
+		// lower top face of directional liquid source by 1/16
+		box.MaxEdge.Y -= 0.0625f * BS;
 	box.MinEdge += cur_node.origin;
 	box.MaxEdge += cur_node.origin;
 	if (data->m_smooth_lighting) {
@@ -562,6 +571,7 @@ void MapblockMeshGenerator::prepareLiquidNodeDrawing()
 	cur_liquid.c_source = cur_node.f->liquid_alternative_source_id;
 	cur_liquid.top_is_same_liquid = (ntop.getContent() == cur_liquid.c_flowing)
 			|| (ntop.getContent() == cur_liquid.c_source);
+	cur_liquid.bottom_is_same_liquid_source = (nbottom.getContent() == cur_liquid.c_source);
 	cur_liquid.draw_bottom = (nbottom.getContent() != cur_liquid.c_flowing)
 			&& (nbottom.getContent() != cur_liquid.c_source);
 	if (cur_liquid.draw_bottom) {
@@ -632,8 +642,11 @@ void MapblockMeshGenerator::getLiquidNeighborhood()
 		//       isn't a liquid
 		p2.Y++;
 		n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
-		if (n2.getContent() == cur_liquid.c_source || n2.getContent() == cur_liquid.c_flowing)
+		content_t top = n2.getContent();
+		if (top == cur_liquid.c_source || top == cur_liquid.c_flowing)
 			neighbor.top_is_same_liquid = true;
+		else if (cur_node.f->param_type_2 == CPT2_DIRECTIONAL_FLOWING || cur_node.f->param_type_2 == CPT2_DIRECTIONAL_SOURCE)
+			neighbor.level -= 0.0625f;
 	}
 }
 
@@ -662,7 +675,7 @@ f32 MapblockMeshGenerator::getCornerLevel(int i, int k) const
 
 		// Source always has the full height
 		if (content == cur_liquid.c_source)
-			return 0.5f;
+			return neighbor_data.level;
 
 		// Flowing liquid has level information
 		if (content == cur_liquid.c_flowing) {
@@ -739,7 +752,7 @@ void MapblockMeshGenerator::drawLiquidSides()
 			pos.X = (base.X - 0.5f) * BS;
 			pos.Z = (base.Z - 0.5f) * BS;
 			if (vertex.v) {
-				pos.Y = (neighbor.is_same_liquid ? cur_liquid.corner_levels[base.Z][base.X] : -0.5f) * BS;
+				pos.Y = (neighbor.is_same_liquid ? cur_liquid.corner_levels[base.Z][base.X] : (cur_liquid.bottom_is_same_liquid_source ? -0.5625f : -0.5f)) * BS;
 			} else if (cur_liquid.top_is_same_liquid) {
 				pos.Y = 0.5f * BS;
 			} else {

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -103,6 +103,7 @@ private:
 		};
 
 		bool top_is_same_liquid;
+		bool bottom_is_same_liquid_source;
 		bool draw_bottom;
 		TileSpec tile;
 		TileSpec tile_top;

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -99,6 +99,7 @@ private:
 			content_t content;
 			bool is_same_liquid;
 			bool top_is_same_liquid;
+			bool is_flowing_down;
 		};
 
 		bool top_is_same_liquid;

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -450,7 +450,8 @@ u8 MapNode::getMaxLevel(const NodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	// todo: after update in all games leave only if (f.param_type_2 ==
-	if( f.liquid_type == LIQUID_FLOWING || f.param_type_2 == CPT2_FLOWINGLIQUID)
+	if( f.liquid_type == LIQUID_FLOWING || f.param_type_2 == CPT2_FLOWINGLIQUID
+			|| f.param_type_2 == CPT2_DIRECTIONAL_FLOWING)
 		return LIQUID_LEVEL_MAX;
 	if(f.leveled || f.param_type_2 == CPT2_LEVELED)
 		return f.leveled_max;
@@ -461,9 +462,9 @@ u8 MapNode::getLevel(const NodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	// todo: after update in all games leave only if (f.param_type_2 ==
-	if(f.liquid_type == LIQUID_SOURCE)
+	if(f.liquid_type == LIQUID_SOURCE || f.param_type_2 == CPT2_DIRECTIONAL_SOURCE)
 		return LIQUID_LEVEL_SOURCE;
-	if (f.param_type_2 == CPT2_FLOWINGLIQUID)
+	if (f.param_type_2 == CPT2_FLOWINGLIQUID || f.param_type_2 == CPT2_DIRECTIONAL_FLOWING)
 		return getParam2() & LIQUID_LEVEL_MASK;
 	if(f.liquid_type == LIQUID_FLOWING) // can remove if all param_type_2 set
 		return getParam2() & LIQUID_LEVEL_MASK;
@@ -483,6 +484,8 @@ s8 MapNode::setLevel(const NodeDefManager *nodemgr, s16 level)
 	s8 rest = 0;
 	const ContentFeatures &f = nodemgr->get(*this);
 	if (f.param_type_2 == CPT2_FLOWINGLIQUID
+			|| f.param_type_2 == CPT2_DIRECTIONAL_FLOWING
+			|| f.param_type_2 == CPT2_DIRECTIONAL_SOURCE
 			|| f.liquid_type == LIQUID_FLOWING
 			|| f.liquid_type == LIQUID_SOURCE) {
 		if (level <= 0) { // liquid can’t exist with zero level

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -93,6 +93,10 @@ enum Rotation {
 #define LIQUID_LEVEL_MASK 0x07
 #define LIQUID_FLOW_DOWN_MASK 0x08
 
+#define LIQUID_DIRECTION_MASK 0xF8
+#define LIQUID_DIRECTION_NONE 0
+#define LIQUID_DIRECTION_DOWN 31
+
 /* maximum amount of liquid in a block */
 #define LIQUID_LEVEL_MAX LIQUID_LEVEL_MASK
 #define LIQUID_LEVEL_SOURCE (LIQUID_LEVEL_MAX+1)

--- a/src/network/networkprotocol.cpp
+++ b/src/network/networkprotocol.cpp
@@ -72,6 +72,7 @@
 		Support for TOCLIENT_SPAWN_PARTICLE_BATCH
 		[scheduled bump for 5.14.0]
 	PROTOCOL VERSION 51
+		New directional liquid param2 types get downgraded for older clients
 		Only send first frame of animated item/wield images to older client
 		[scheduled bump for 5.15.0]
 */

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -367,6 +367,7 @@ void ContentFeatures::reset()
 	liquid_viscosity = 0;
 	liquid_renewable = true;
 	liquid_range = LIQUID_LEVEL_MAX+1;
+	liquid_directed_range = 7;
 	drowning = 0;
 	light_source = 0;
 	damage_per_second = 0;
@@ -430,7 +431,16 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 		}
 	}
 	writeU8(os, param_type);
-	writeU8(os, param_type_2);
+	ContentParamType2 pt2 = param_type_2;
+	if (protocol_version < 51) {
+		// old clients don't know about directional liquids, but
+		// handle them just fine with only minor visual issues
+		if (pt2 == CPT2_DIRECTIONAL_FLOWING)
+			pt2 = CPT2_FLOWINGLIQUID;
+		else if (pt2 == CPT2_DIRECTIONAL_SOURCE)
+			pt2 = CPT2_NONE;
+	}
+	writeU8(os, pt2);
 
 	// visual
 	writeU8(os, drawtype);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -66,6 +66,13 @@ enum ContentParamType2 : u8
 	CPT2_4DIR,
 	// 6 bits of palette index, then 4dir
 	CPT2_COLORED_4DIR,
+	// Flowing liquid properties with level in the lower 3 bits and optional
+        // direction in the upper 5 bits; 0: no direction, 31: flowing down,
+        // 1-28: direction and distance to downflow, (x-1) % 4 = direction,
+        // (x-1) / 4 = distance
+	CPT2_DIRECTIONAL_FLOWING,
+	// Liquid source properties with optional direction in the upper 5 bits
+	CPT2_DIRECTIONAL_SOURCE,
 	// Dummy for validity check
 	ContentParamType2_END
 };
@@ -405,6 +412,8 @@ struct ContentFeatures
 	bool liquid_renewable;
 	// Number of flowing liquids surrounding source
 	u8 liquid_range;
+	// maximum length of a directed flow, range 0-7
+	u8 liquid_directed_range;
 	u8 drowning;
 	// Liquids flow into and replace node
 	bool floodable;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -934,6 +934,8 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 	f.move_resistance = f.liquid_viscosity;
 	f.liquid_range = getintfield_default(L, index,
 			"liquid_range", f.liquid_range);
+	f.liquid_directed_range = getintfield_default(L, index,
+			"liquid_directed_range", f.liquid_directed_range);
 	f.leveled = getintfield_default(L, index, "leveled", f.leveled);
 	f.leveled_max = getintfield_default(L, index,
 			"leveled_max", f.leveled_max);
@@ -1161,6 +1163,8 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 		lua_setfield(L, -2, "liquid_renewable");
 		lua_pushnumber(L, c.liquid_range);
 		lua_setfield(L, -2, "liquid_range");
+		lua_pushnumber(L, c.liquid_directed_range);
+		lua_setfield(L, -2, "liquid_directed_range");
 	}
 	lua_pushnumber(L, c.drowning);
 	lua_setfield(L, -2, "drowning");

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -53,6 +53,8 @@ struct EnumString ScriptApiNode::es_ContentParamType2[] =
 		{CPT2_COLORED_DEGROTATE, "colordegrotate"},
 		{CPT2_4DIR, "4dir"},
 		{CPT2_COLORED_4DIR, "color4dir"},
+		{CPT2_DIRECTIONAL_FLOWING, "directionalflowing"},
+		{CPT2_DIRECTIONAL_SOURCE, "directionalsource"},
 		{0, NULL},
 	};
 

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -1170,7 +1170,6 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			update the current node
 		 */
 		MapNode n00 = n0;
-		//bool flow_down_enabled = (flowing_down && ((n0.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK));
 		if (m_nodedef->get(new_node_content).liquid_type == LIQUID_FLOWING) {
 			// set level to last 3 bits, flowing down bit to 4th bit
 			n0.param2 = (flowing_down ? LIQUID_FLOW_DOWN_MASK : 0x00) | (new_node_level & LIQUID_LEVEL_MASK);

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -1090,9 +1090,11 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 						if (liquid_kind == CONTENT_AIR &&
 								max_level_from_neighbor >= (LIQUID_LEVEL_MAX + 1 - range))
 							liquid_kind = cfnb.liquid_alternative_flowing_id;
+						if (cfnb.liquid_alternative_flowing_id == liquid_kind &&
+								max_level_from_neighbor > max_node_level)
+							max_node_level = max_level_from_neighbor;
 					}
 					if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
-						max_node_level = get_max_node_level(nb, max_node_level);
 						if (nb.t == NEIGHBOR_LOWER)
 							flowing_down = true;
 					}

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -996,7 +996,6 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		/*
 			Collect information about the environment
 		 */
-		NodeNeighbor sources[6]; // surrounding sources
 		int num_sources = 0;
 		NodeNeighbor flows[6]; // surrounding flowing liquid nodes
 		int num_flows = 0;
@@ -1053,7 +1052,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 					if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
 						// Do not count bottom source, it will screw things up
 						if(nt != NEIGHBOR_LOWER)
-							sources[num_sources++] = nb;
+							num_sources++;
 					}
 					break;
 				case LIQUID_FLOWING:
@@ -1097,7 +1096,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			// or the flowing alternative of the first of the surrounding sources (if it's air), so
 			// it's perfectly safe to use liquid_kind here to determine the new node content.
 			new_node_content = m_nodedef->get(liquid_kind).liquid_alternative_source_id;
-		} else if (num_sources >= 1 && sources[0].t != NEIGHBOR_LOWER) {
+		} else if (num_sources >= 1) {
 			// liquid_kind is set properly, see above
 			max_node_level = new_node_level = LIQUID_LEVEL_MAX;
 			if (new_node_level >= (LIQUID_LEVEL_MAX + 1 - range))

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -908,7 +908,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 	ScopeProfiler sp_max(g_profiler, "ServerMap: transformLiquids max", SPT_MAX);
 
 	u32 loopcount = 0;
+	u32 loopcountdir = 0;
 	u32 looptransform = 0;
+	u32 looptransformdir = 0;
 
 	/*if(initial_size != 0)
 		infostream<<"transformLiquids(): initial_size="<<initial_size<<std::endl;*/
@@ -939,6 +941,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			Collect information about current node
 		 */
 		s8 node_level = -1;
+		u8 dirdist = 0;
 		// The liquid node which will be placed there if
 		// the liquid flows into this node.
 		content_t liquid_kind = CONTENT_IGNORE;
@@ -947,16 +950,26 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		content_t floodable_node = CONTENT_AIR;
 		content_t node_content = n0.getContent();
 		const ContentFeatures &cf = m_nodedef->get(node_content);
+		bool directional = cf.param_type_2 == CPT2_DIRECTIONAL_FLOWING
+			|| cf.param_type_2 == CPT2_DIRECTIONAL_SOURCE;
 		LiquidType liquid_type = cf.liquid_type;
 		s8 max_node_level = -1;
 		switch (liquid_type) {
 			case LIQUID_SOURCE:
 				// liquid source has no node level
 				liquid_kind = cf.liquid_alternative_flowing_id;
+				if (directional)
+					dirdist = (n0.param2 & LIQUID_DIRECTION_MASK) >> 3;
 				break;
 			case LIQUID_FLOWING:
 				node_level = (n0.param2 & LIQUID_LEVEL_MASK);
 				liquid_kind = node_content;
+				if (directional)
+					dirdist = (n0.param2 & LIQUID_DIRECTION_MASK) >> 3;
+				else
+					// CPT2_FLOWINGLIQUID only encoding down direction
+					dirdist = (n0.param2 & LIQUID_FLOW_DOWN_MASK) ?
+						LIQUID_DIRECTION_DOWN : LIQUID_DIRECTION_NONE;
 				break;
 			case LIQUID_NONE:
 				// if this node is 'floodable', it *could* be transformed
@@ -981,6 +994,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		bool flowing_down = false;
 		bool ignore_node_found = false;
 		bool floating_node_above = false;
+		u8 new_dirdist = 0;
 		for (u16 i = 0; i < 6; i++) {
 			NeighborType nt = NEIGHBOR_SAME_LEVEL;
 			switch (i) {
@@ -996,6 +1010,17 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			v3s16 npos = p0 + liquid_6dirs[i];
 			NodeNeighbor nb(getNode(npos), nt, npos);
 			const ContentFeatures &cfnb = m_nodedef->get(nb.n);
+			bool nb_directional = cfnb.param_type_2 == CPT2_DIRECTIONAL_FLOWING
+				|| cfnb.param_type_2 == CPT2_DIRECTIONAL_SOURCE;
+			u8 nb_dirdist;
+			if (nb_directional)
+				nb_dirdist = (nb.n.param2 & LIQUID_DIRECTION_MASK) >> 3;
+			else if (cfnb.param_type_2 == CPT2_FLOWINGLIQUID)
+				nb_dirdist = (nb.n.param2 & LIQUID_FLOW_DOWN_MASK) ?
+					LIQUID_DIRECTION_DOWN : LIQUID_DIRECTION_NONE;
+			else
+				// non directional source or non liquid node
+				nb_dirdist = 0;
 			if (nt == NEIGHBOR_UPPER && cfnb.floats)
 				floating_node_above = true;
 			switch (cfnb.liquid_type) {
@@ -1065,7 +1090,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 								break;
 							case NEIGHBOR_SAME_LEVEL:
 								// exclude falling liquids on the same level, they cannot flow here anyway
-								if ((nb.n.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK &&
+								if (nb_dirdist != LIQUID_DIRECTION_DOWN &&
 										nb_node_level > 0)
 									max_level_from_neighbor = nb_node_level - 1;
 								break;
@@ -1121,6 +1146,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			// Maybe there are neighboring flows that aren't loaded yet,
 			// so prevent flowing away
 			new_node_level = node_level;
+			new_dirdist = dirdist;
 			new_node_content = liquid_kind;
 		} else {
 			u8 viscosity = m_nodedef->get(liquid_kind).liquid_viscosity;
@@ -1148,19 +1174,52 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		}
 
 		const ContentFeatures &cfnew = m_nodedef->get(new_node_content);
+		ContentParamType2 pt2 = cfnew.param_type_2;
+		if (pt2 == CPT2_NONE && liquid_type == LIQUID_FLOWING && new_node_level >= 0)
+			pt2 = CPT2_FLOWINGLIQUID;
+		bool new_directional = (pt2 == CPT2_DIRECTIONAL_FLOWING || pt2 == CPT2_DIRECTIONAL_SOURCE);
+		u8 directed_range = new_directional ? cfnew.liquid_directed_range : 0;
+		if (directed_range > 7)
+			// can only encode distances 0-6 in flows
+			directed_range = 7;
+
+		/*
+			finalize direction
+		 */
+		if (flowing_down)
+			new_dirdist = LIQUID_DIRECTION_DOWN;
+		else if (pt2 == CPT2_DIRECTIONAL_FLOWING &&
+				(new_dirdist > (directed_range * 4)
+						|| (max_node_level < LIQUID_LEVEL_MAX + 1 - directed_range)
+						|| new_dirdist > ((max_node_level - 8 + range) * 4)))
+			// cannot become directional if out of directed range
+			new_dirdist = 0;
+		else if (pt2 == CPT2_DIRECTIONAL_SOURCE && new_dirdist > 4)
+			// source doesn't encode distance
+			new_dirdist = (new_dirdist - 1) % 4 + 1;
+
+		// count directional node
+		if (new_directional && new_dirdist)
+			loopcountdir += 1;
 
 		/*
 			check if anything has changed. if not, just continue with the next node.
 		 */
-		if (new_node_content == node_content &&
-				(liquid_type != LIQUID_FLOWING ||
-				(new_node_level == node_level &&
-				((n0.param2 & LIQUID_FLOW_DOWN_MASK) == LIQUID_FLOW_DOWN_MASK)
-				== flowing_down)))
-			continue;
+		if (new_node_content == node_content) {
+			bool same = true;
+			if (pt2 == CPT2_DIRECTIONAL_FLOWING || pt2 == CPT2_FLOWINGLIQUID)
+				same &= (new_node_level == node_level &&
+						flowing_down == (dirdist == LIQUID_DIRECTION_DOWN));
+			if (new_directional)
+				same &= (new_dirdist == dirdist);
+			if (same)
+				continue;
+		}
 
                 // count changed node
 		looptransform += 1;
+		if (new_directional && new_dirdist)
+			looptransformdir += 1;
 
 		/*
 			check if there is a floating node above that needs to be updated.
@@ -1168,16 +1227,30 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		if (floating_node_above && new_node_content == CONTENT_AIR)
 			check_for_falling.push_back(p0);
 
+		// remember old state of current node
+		MapNode n00 = n0;
+
 		/*
 			update the current node
 		 */
-		MapNode n00 = n0;
-		if (cfnew.liquid_type == LIQUID_FLOWING) {
-			// set level to last 3 bits, flowing down bit to 4th bit
-			n0.param2 = (flowing_down ? LIQUID_FLOW_DOWN_MASK : 0x00) | (new_node_level & LIQUID_LEVEL_MASK);
+		if (new_directional) {
+			// reset complete param2 for directional flows
+			n0.param2 = ((new_dirdist << 3) & LIQUID_DIRECTION_MASK);
+		} else if (pt2 == CPT2_FLOWINGLIQUID) {
+			// reset complete param2 for non directional flowing liquids
+			n0.param2 = flowing_down ? LIQUID_FLOW_DOWN_MASK : 0x00;
+		} else if (directional) {
+			// reset complete param2 for evaporated directional liquids
+			n0.param2 = 0;
 		} else {
-			// set the liquid level and flow bits to 0
+			// preserve upper 4 bits for backwards compatibility
+			// TODO: decide whether that is really necessary
 			n0.param2 &= ~(LIQUID_LEVEL_MASK | LIQUID_FLOW_DOWN_MASK);
+		}
+
+		if (pt2 == CPT2_DIRECTIONAL_FLOWING || pt2 == CPT2_FLOWINGLIQUID) {
+			// finally set level bits for flowing liquids
+			n0.param2 |= (new_node_level & LIQUID_LEVEL_MASK);
 		}
 
 		// change the node.
@@ -1250,7 +1323,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 	}
 
 	g_profiler->add("ServerMap: transformLiquids: processed", loopcount);
+	g_profiler->add("ServerMap: transformLiquids: processed (dir)", loopcountdir);
 	g_profiler->add("ServerMap: transformLiquids: changed", looptransform);
+	g_profiler->add("ServerMap: transformLiquids: changed (dir)", looptransformdir);
 
 	for (const auto &iter : must_reflow)
 		liquid_queue.push_back(iter);

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -1093,10 +1093,11 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 					}
 					if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
 						max_node_level = get_max_node_level(nb, max_node_level);
-						flows[num_flows++] = nb;
 						if (nb.t == NEIGHBOR_LOWER)
 							flowing_down = true;
 					}
+					// Take note of all flows
+					flows[num_flows++] = nb;
 					break;
 				case LiquidType_END:
 					break;
@@ -1239,7 +1240,8 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			case LIQUID_FLOWING:
 				// make sure source flows into all neighboring nodes
 				for (u16 i = 0; i < num_flows; i++)
-					if (flows[i].t != NEIGHBOR_UPPER)
+					if (flows[i].t != NEIGHBOR_UPPER &&
+							m_nodedef->get(flows[i].n).liquid_alternative_flowing_id == liquid_kind)
 						liquid_queue.push_back(flows[i].p);
 				for (u16 i = 0; i < num_airs; i++)
 					if (airs[i].t != NEIGHBOR_UPPER)
@@ -1248,7 +1250,8 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			case LIQUID_NONE:
 				// this flow has turned to air; neighboring flows might need to do the same
 				for (u16 i = 0; i < num_flows; i++)
-					liquid_queue.push_back(flows[i].p);
+					if (m_nodedef->get(flows[i].n).liquid_alternative_flowing_id == liquid_kind)
+						liquid_queue.push_back(flows[i].p);
 				break;
 			case LiquidType_END:
 				break;

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -1078,8 +1078,8 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 					}
 					break;
 				case LIQUID_FLOWING:
-					if (nb.t != NEIGHBOR_SAME_LEVEL ||
-						(nb.n.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK) {
+					// Lower flows cannot flow here
+					if (nb.t != NEIGHBOR_LOWER) {
 						// if this node is not (yet) of a liquid type, choose the first liquid type we encounter
 						// but exclude falling liquids on the same level, they cannot flow here anyway
 
@@ -1093,10 +1093,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 						if (cfnb.liquid_alternative_flowing_id == liquid_kind &&
 								max_level_from_neighbor > max_node_level)
 							max_node_level = max_level_from_neighbor;
-					}
-					if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
-						if (nb.t == NEIGHBOR_LOWER)
-							flowing_down = true;
+					} else if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
+						// mark flowing down
+						flowing_down = true;
 					}
 					// Take note of all flows
 					flows[num_flows++] = nb;

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -896,26 +896,26 @@ struct NodeNeighbor {
 	{ }
 };
 
-static s8 get_max_liquid_level(NodeNeighbor nb, s8 current_max_node_level)
+static s8 get_max_node_level(NodeNeighbor nb, s8 current_max_node_level)
 {
 	s8 max_node_level = current_max_node_level;
-	u8 nb_liquid_level = (nb.n.param2 & LIQUID_LEVEL_MASK);
+	u8 nb_node_level = (nb.n.param2 & LIQUID_LEVEL_MASK);
 	switch (nb.t) {
 		case NEIGHBOR_UPPER:
-			if (nb_liquid_level + WATER_DROP_BOOST > current_max_node_level) {
+			if (nb_node_level + WATER_DROP_BOOST > current_max_node_level) {
 				max_node_level = LIQUID_LEVEL_MAX;
-				if (nb_liquid_level + WATER_DROP_BOOST < LIQUID_LEVEL_MAX)
-					max_node_level = nb_liquid_level + WATER_DROP_BOOST;
-			} else if (nb_liquid_level > current_max_node_level) {
-				max_node_level = nb_liquid_level;
+				if (nb_node_level + WATER_DROP_BOOST < LIQUID_LEVEL_MAX)
+					max_node_level = nb_node_level + WATER_DROP_BOOST;
+			} else if (nb_node_level > current_max_node_level) {
+				max_node_level = nb_node_level;
 			}
 			break;
 		case NEIGHBOR_LOWER:
 			break;
 		case NEIGHBOR_SAME_LEVEL:
 			if ((nb.n.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK &&
-					nb_liquid_level > 0 && nb_liquid_level - 1 > max_node_level)
-				max_node_level = nb_liquid_level - 1;
+					nb_node_level > 0 && nb_node_level - 1 > max_node_level)
+				max_node_level = nb_node_level - 1;
 			break;
 	}
 	return max_node_level;
@@ -963,7 +963,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		/*
 			Collect information about current node
 		 */
-		s8 liquid_level = -1;
+		s8 node_level = -1;
 		// The liquid node which will be placed there if
 		// the liquid flows into this node.
 		content_t liquid_kind = CONTENT_IGNORE;
@@ -974,11 +974,11 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		LiquidType liquid_type = cf.liquid_type;
 		switch (liquid_type) {
 			case LIQUID_SOURCE:
-				liquid_level = LIQUID_LEVEL_SOURCE;
+				// liquid source has no node level
 				liquid_kind = cf.liquid_alternative_flowing_id;
 				break;
 			case LIQUID_FLOWING:
-				liquid_level = (n0.param2 & LIQUID_LEVEL_MASK);
+				node_level = (n0.param2 & LIQUID_LEVEL_MASK);
 				liquid_kind = n0.getContent();
 				break;
 			case LIQUID_NONE:
@@ -1063,7 +1063,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 						// but exclude falling liquids on the same level, they cannot flow here anyway
 
 						// used to determine if the neighbor can even flow into this node
-						s8 max_level_from_neighbor = get_max_liquid_level(nb, -1);
+						s8 max_level_from_neighbor = get_max_node_level(nb, -1);
 						u8 range = m_nodedef->get(cfnb.liquid_alternative_flowing_id).liquid_range;
 
 						if (liquid_kind == CONTENT_AIR &&
@@ -1104,28 +1104,28 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 				new_node_content = liquid_kind;
 			else
 				new_node_content = floodable_node;
-		} else if (ignore_node_found && liquid_level >= 0) {
+		} else if (ignore_node_found && node_level >= 0) {
 			// Maybe there are neighboring flows that aren't loaded yet,
 			// so prevent flowing away
-			new_node_level = liquid_level;
+			new_node_level = node_level;
 			new_node_content = liquid_kind;
 		} else {
 			// no surrounding sources, so get the maximum level that can flow into this node
 			for (u16 i = 0; i < num_flows; i++) {
-				max_node_level = get_max_liquid_level(flows[i], max_node_level);
+				max_node_level = get_max_node_level(flows[i], max_node_level);
 			}
 
 			u8 viscosity = m_nodedef->get(liquid_kind).liquid_viscosity;
-			if (viscosity > 1 && max_node_level != liquid_level) {
+			if (viscosity > 1 && max_node_level != node_level) {
 				// amount to gain, limited by viscosity
 				// must be at least 1 in absolute value
-				s8 level_inc = max_node_level - liquid_level;
+				s8 level_inc = max_node_level - node_level;
 				if (level_inc < -viscosity || level_inc > viscosity)
-					new_node_level = liquid_level + level_inc/viscosity;
+					new_node_level = node_level + level_inc/viscosity;
 				else if (level_inc < 0)
-					new_node_level = liquid_level - 1;
+					new_node_level = node_level - 1;
 				else if (level_inc > 0)
-					new_node_level = liquid_level + 1;
+					new_node_level = node_level + 1;
 				if (new_node_level != max_node_level)
 					must_reflow.push_back(p0);
 			} else {

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -956,7 +956,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		s8 max_node_level = -1;
 		switch (liquid_type) {
 			case LIQUID_SOURCE:
-				// liquid source has no node level
+				// liquid source has no node level, but 'conversion'
+				// by neighbors needs to be prevented
+				max_node_level = LIQUID_LEVEL_SOURCE;
 				liquid_kind = cf.liquid_alternative_flowing_id;
 				if (directional)
 					dirdist = (n0.param2 & LIQUID_DIRECTION_MASK) >> 3;
@@ -1065,13 +1067,16 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 						}
 
 						if (can_flow_here) {
-							// if this node is not (yet) of a liquid type,
-							// choose the first liquid type we encounter
-							if (liquid_kind == CONTENT_AIR) {
+							// choose this source if no other source found yet
+							if (liquid_kind == CONTENT_AIR || max_node_level <= LIQUID_LEVEL_MAX) {
 								liquid_kind = cfnb.liquid_alternative_flowing_id;
+								// prevent conversion by other source by using MAX+1
+								// note that this value will never be used to determine liquid level
+								max_node_level = LIQUID_LEVEL_SOURCE;
 							}
 							if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
 								// count number of sources that could flow here
+								// note that liquid type will never change after a source node neighbor has been found
 								num_sources++;
 							}
 						}
@@ -1100,9 +1105,13 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 						}
 						u8 range = m_nodedef->get(cfnb.liquid_alternative_flowing_id).liquid_range;
 
-						// if this node is not (yet) of a liquid type, choose the first
-						// liquid type we encounter that can flow into this node
-						if (liquid_kind == CONTENT_AIR &&
+						// choose neighbor flow if none found yet or if it
+						// is directional and provides higher liquid level;
+						// it also needs the range to actually flow here
+						if ((liquid_kind == CONTENT_AIR ||
+                                                        (nb_directional &&
+									max_level_from_neighbor > max_node_level &&
+									max_level_from_neighbor > node_level)) &&
 								max_level_from_neighbor >= (LIQUID_LEVEL_MAX + 1 - range))
 							liquid_kind = cfnb.liquid_alternative_flowing_id;
 						if (cfnb.liquid_alternative_flowing_id == liquid_kind &&
@@ -1149,6 +1158,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			new_dirdist = dirdist;
 			new_node_content = liquid_kind;
 		} else {
+			// no neighboring source found, so max_node_level <= LIQUID_LEVEL_MAX
 			u8 viscosity = m_nodedef->get(liquid_kind).liquid_viscosity;
 			if (viscosity > 1 && max_node_level != node_level) {
 				// amount to gain, limited by viscosity
@@ -1303,11 +1313,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		switch (cfnew.liquid_type) {
 			case LIQUID_SOURCE:
 			case LIQUID_FLOWING:
-				// make sure source flows into all neighboring nodes
+				// make sure all neighboring flows update their state (incl. flowing down)
 				for (u16 i = 0; i < num_flows; i++)
-					if (flows[i].t != NEIGHBOR_UPPER &&
-							m_nodedef->get(flows[i].n).liquid_alternative_flowing_id == liquid_kind)
-						liquid_queue.push_back(flows[i].p);
+					liquid_queue.push_back(flows[i].p);
 				for (u16 i = 0; i < num_airs; i++)
 					if (airs[i].t != NEIGHBOR_UPPER)
 						liquid_queue.push_back(airs[i].p);

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -1002,8 +1002,6 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		int num_flows = 0;
 		NodeNeighbor airs[6]; // surrounding air
 		int num_airs = 0;
-		NodeNeighbor neutrals[6]; // nodes that are solid or another kind of liquid
-		int num_neutrals = 0;
 		bool flowing_down = false;
 		bool ignored_sources = false;
 		bool floating_node_above = false;
@@ -1037,7 +1035,6 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 						if (nb.t == NEIGHBOR_LOWER)
 							flowing_down = true;
 					} else {
-						neutrals[num_neutrals++] = nb;
 						if (nb.n.getContent() == CONTENT_IGNORE) {
 							// If node below is ignore prevent water from
 							// spreading outwards and otherwise prevent from
@@ -1053,9 +1050,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 					// if this node is not (yet) of a liquid type, choose the first liquid type we encounter
 					if (liquid_kind == CONTENT_AIR)
 						liquid_kind = cfnb.liquid_alternative_flowing_id;
-					if (cfnb.liquid_alternative_flowing_id != liquid_kind) {
-						neutrals[num_neutrals++] = nb;
-					} else {
+					if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
 						// Do not count bottom source, it will screw things up
 						if(nt != NEIGHBOR_LOWER)
 							sources[num_sources++] = nb;
@@ -1075,9 +1070,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 								max_level_from_neighbor >= (LIQUID_LEVEL_MAX + 1 - range))
 							liquid_kind = cfnb.liquid_alternative_flowing_id;
 					}
-					if (cfnb.liquid_alternative_flowing_id != liquid_kind) {
-						neutrals[num_neutrals++] = nb;
-					} else {
+					if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
 						flows[num_flows++] = nb;
 						if (nb.t == NEIGHBOR_LOWER)
 							flowing_down = true;

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -1002,7 +1002,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		NodeNeighbor airs[6]; // surrounding air
 		int num_airs = 0;
 		bool flowing_down = false;
-		bool ignored_sources = false;
+		bool ignore_node_found = false;
 		bool floating_node_above = false;
 		for (u16 i = 0; i < 6; i++) {
 			NeighborType nt = NEIGHBOR_SAME_LEVEL;
@@ -1036,12 +1036,13 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 					} else {
 						if (nb.n.getContent() == CONTENT_IGNORE) {
 							// If node below is ignore prevent water from
-							// spreading outwards and otherwise prevent from
-							// flowing away as ignore node might be the source
+							// spreading outwards, otherwise prevent from
+							// flowing away as the ignore node might be
+							// flowing here
 							if (nb.t == NEIGHBOR_LOWER)
 								flowing_down = true;
 							else
-								ignored_sources = true;
+								ignore_node_found = true;
 						}
 					}
 					break;
@@ -1103,9 +1104,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 				new_node_content = liquid_kind;
 			else
 				new_node_content = floodable_node;
-		} else if (ignored_sources && liquid_level >= 0) {
-			// Maybe there are neighboring sources that aren't loaded yet
-			// so prevent flowing away.
+		} else if (ignore_node_found && liquid_level >= 0) {
+			// Maybe there are neighboring flows that aren't loaded yet,
+			// so prevent flowing away
 			new_node_level = liquid_level;
 			new_node_content = liquid_kind;
 		} else {

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -970,7 +970,8 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		// The node which will be placed there if liquid
 		// can't flow into this node.
 		content_t floodable_node = CONTENT_AIR;
-		const ContentFeatures &cf = m_nodedef->get(n0);
+		content_t node_content = n0.getContent();
+		const ContentFeatures &cf = m_nodedef->get(node_content);
 		LiquidType liquid_type = cf.liquid_type;
 		switch (liquid_type) {
 			case LIQUID_SOURCE:
@@ -979,14 +980,14 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 				break;
 			case LIQUID_FLOWING:
 				node_level = (n0.param2 & LIQUID_LEVEL_MASK);
-				liquid_kind = n0.getContent();
+				liquid_kind = node_content;
 				break;
 			case LIQUID_NONE:
 				// if this node is 'floodable', it *could* be transformed
 				// into a liquid, otherwise, continue with the next node.
 				if (!cf.floodable)
 					continue;
-				floodable_node = n0.getContent();
+				floodable_node = node_content;
 				liquid_kind = CONTENT_AIR;
 				break;
 			case LiquidType_END:
@@ -1158,13 +1159,14 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 
 		}
 
+		const ContentFeatures &cfnew = m_nodedef->get(new_node_content);
 
 		/*
 			check if anything has changed. if not, just continue with the next node.
 		 */
-		if (new_node_content == n0.getContent() &&
-				(m_nodedef->get(n0.getContent()).liquid_type != LIQUID_FLOWING ||
-				((n0.param2 & LIQUID_LEVEL_MASK) == (u8)new_node_level &&
+		if (new_node_content == node_content &&
+				(liquid_type != LIQUID_FLOWING ||
+				(new_node_level == node_level &&
 				((n0.param2 & LIQUID_FLOW_DOWN_MASK) == LIQUID_FLOW_DOWN_MASK)
 				== flowing_down)))
 			continue;
@@ -1182,7 +1184,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			update the current node
 		 */
 		MapNode n00 = n0;
-		if (m_nodedef->get(new_node_content).liquid_type == LIQUID_FLOWING) {
+		if (cfnew.liquid_type == LIQUID_FLOWING) {
 			// set level to last 3 bits, flowing down bit to 4th bit
 			n0.param2 = (flowing_down ? LIQUID_FLOW_DOWN_MASK : 0x00) | (new_node_level & LIQUID_LEVEL_MASK);
 		} else {
@@ -1236,7 +1238,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		/*
 			enqueue neighbors for update if necessary
 		 */
-		switch (m_nodedef->get(n0.getContent()).liquid_type) {
+		switch (cfnew.liquid_type) {
 			case LIQUID_SOURCE:
 			case LIQUID_FLOWING:
 				// make sure source flows into all neighboring nodes

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -1297,8 +1297,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		}
 
 		/*
-			enqueue neighbors for update if necessary
+			enqueue nodes for update if necessary
 		 */
+		bool other_kind = false;
 		switch (cfnew.liquid_type) {
 			case LIQUID_SOURCE:
 			case LIQUID_FLOWING:
@@ -1316,6 +1317,13 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 				for (u16 i = 0; i < num_flows; i++)
 					if (m_nodedef->get(flows[i].n).liquid_alternative_flowing_id == liquid_kind)
 						liquid_queue.push_back(flows[i].p);
+					else
+						other_kind = true;
+				// don't do this update for classic flows for backwards compatibility
+				// TODO: decide whether this should be fixed for classic liquids, too
+				if (directional && other_kind)
+					// other liquid kind may now flow into this node
+					liquid_queue.push_back(p0);
 				break;
 			case LiquidType_END:
 				break;

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -929,7 +929,11 @@ void ServerMap::transforming_liquid_add(v3s16 p)
 void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_blocks, UniqueQueue<v3s16> &liquid_queue,
 		ServerEnvironment *env, u32 liquid_loop_max)
 {
+	ScopeProfiler sp_avg(g_profiler, "ServerMap: transformLiquids avg", SPT_AVG);
+	ScopeProfiler sp_max(g_profiler, "ServerMap: transformLiquids max", SPT_MAX);
+
 	u32 loopcount = 0;
+	u32 looptransform = 0;
 
 	/*if(initial_size != 0)
 		infostream<<"transformLiquids(): initial_size="<<initial_size<<std::endl;*/
@@ -1142,6 +1146,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 
 		}
 
+
 		/*
 			check if anything has changed. if not, just continue with the next node.
 		 */
@@ -1151,6 +1156,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 				((n0.param2 & LIQUID_FLOW_DOWN_MASK) == LIQUID_FLOW_DOWN_MASK)
 				== flowing_down)))
 			continue;
+
+                // count changed node
+		looptransform += 1;
 
 		/*
 			check if there is a floating node above that needs to be updated.
@@ -1237,7 +1245,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 				break;
 		}
 	}
-	//infostream<<"Map::transformLiquids(): loopcount="<<loopcount<<std::endl;
+
+	g_profiler->add("ServerMap: transformLiquids: processed", loopcount);
+	g_profiler->add("ServerMap: transformLiquids: changed", looptransform);
 
 	for (const auto &iter : must_reflow)
 		liquid_queue.push_back(iter);

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -896,31 +896,6 @@ struct NodeNeighbor {
 	{ }
 };
 
-static s8 get_max_node_level(NodeNeighbor nb, s8 current_max_node_level)
-{
-	s8 max_node_level = current_max_node_level;
-	u8 nb_node_level = (nb.n.param2 & LIQUID_LEVEL_MASK);
-	switch (nb.t) {
-		case NEIGHBOR_UPPER:
-			if (nb_node_level + WATER_DROP_BOOST > current_max_node_level) {
-				max_node_level = LIQUID_LEVEL_MAX;
-				if (nb_node_level + WATER_DROP_BOOST < LIQUID_LEVEL_MAX)
-					max_node_level = nb_node_level + WATER_DROP_BOOST;
-			} else if (nb_node_level > current_max_node_level) {
-				max_node_level = nb_node_level;
-			}
-			break;
-		case NEIGHBOR_LOWER:
-			break;
-		case NEIGHBOR_SAME_LEVEL:
-			if ((nb.n.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK &&
-					nb_node_level > 0 && nb_node_level - 1 > max_node_level)
-				max_node_level = nb_node_level - 1;
-			break;
-	}
-	return max_node_level;
-}
-
 void ServerMap::transforming_liquid_add(v3s16 p)
 {
 	m_transforming_liquid.push_back(p);
@@ -1080,13 +1055,28 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 				case LIQUID_FLOWING:
 					// Lower flows cannot flow here
 					if (nb.t != NEIGHBOR_LOWER) {
-						// if this node is not (yet) of a liquid type, choose the first liquid type we encounter
-						// but exclude falling liquids on the same level, they cannot flow here anyway
-
-						// used to determine if the neighbor can even flow into this node
-						s8 max_level_from_neighbor = get_max_node_level(nb, -1);
+						s8 max_level_from_neighbor = -1;
+						u8 nb_node_level = (nb.n.param2 & LIQUID_LEVEL_MASK);
+						switch (nb.t) {
+							case NEIGHBOR_UPPER:
+								max_level_from_neighbor = LIQUID_LEVEL_MAX;
+								if (nb_node_level + WATER_DROP_BOOST < LIQUID_LEVEL_MAX)
+									max_level_from_neighbor = nb_node_level + WATER_DROP_BOOST;
+								break;
+							case NEIGHBOR_SAME_LEVEL:
+								// exclude falling liquids on the same level, they cannot flow here anyway
+								if ((nb.n.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK &&
+										nb_node_level > 0)
+									max_level_from_neighbor = nb_node_level - 1;
+								break;
+							case NEIGHBOR_LOWER:
+								// never happens
+								break;
+						}
 						u8 range = m_nodedef->get(cfnb.liquid_alternative_flowing_id).liquid_range;
 
+						// if this node is not (yet) of a liquid type, choose the first
+						// liquid type we encounter that can flow into this node
 						if (liquid_kind == CONTENT_AIR &&
 								max_level_from_neighbor >= (LIQUID_LEVEL_MAX + 1 - range))
 							liquid_kind = cfnb.liquid_alternative_flowing_id;

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -1100,7 +1100,10 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 								num_sources++;
 							}
 						}
-					}
+					} else if (cfnb.liquid_alternative_flowing_id == liquid_kind &&
+							cf.param_type_2 == CPT2_DIRECTIONAL_FLOWING)
+						// flowing liquid doesn't spread on source
+						flowing_down = true;
 					break;
 				case LIQUID_FLOWING:
 					// Lower flows cannot flow here

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -973,6 +973,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		content_t node_content = n0.getContent();
 		const ContentFeatures &cf = m_nodedef->get(node_content);
 		LiquidType liquid_type = cf.liquid_type;
+		s8 max_node_level = -1;
 		switch (liquid_type) {
 			case LIQUID_SOURCE:
 				// liquid source has no node level
@@ -1091,6 +1092,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 							liquid_kind = cfnb.liquid_alternative_flowing_id;
 					}
 					if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
+						max_node_level = get_max_node_level(nb, max_node_level);
 						flows[num_flows++] = nb;
 						if (nb.t == NEIGHBOR_LOWER)
 							flowing_down = true;
@@ -1106,7 +1108,6 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		 */
 		content_t new_node_content;
 		s8 new_node_level = -1;
-		s8 max_node_level = -1;
 
 		u8 range = m_nodedef->get(liquid_kind).liquid_range;
 		if (range > LIQUID_LEVEL_MAX + 1)
@@ -1130,11 +1131,6 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			new_node_level = node_level;
 			new_node_content = liquid_kind;
 		} else {
-			// no surrounding sources, so get the maximum level that can flow into this node
-			for (u16 i = 0; i < num_flows; i++) {
-				max_node_level = get_max_node_level(flows[i], max_node_level);
-			}
-
 			u8 viscosity = m_nodedef->get(liquid_kind).liquid_viscosity;
 			if (viscosity > 1 && max_node_level != node_level) {
 				// amount to gain, limited by viscosity

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -999,6 +999,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		NodeNeighbor airs[6]; // surrounding air
 		int num_airs = 0;
 		bool flowing_down = false;
+		bool liquid_below = false;
 		bool ignore_node_found = false;
 		bool floating_node_above = false;
 		u8 new_dirdist = 0;
@@ -1106,10 +1107,14 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 									directional_sources[num_directional_sources++] = nb;
 							}
 						}
-					} else if (cfnb.liquid_alternative_flowing_id == liquid_kind &&
+					} else {
+						if (cfnb.liquid_alternative_flowing_id == liquid_kind &&
 							cf.param_type_2 == CPT2_DIRECTIONAL_FLOWING)
-						// flowing liquid doesn't spread on source
-						flowing_down = true;
+							// flowing liquid doesn't spread on source
+							flowing_down = true;
+						else
+							liquid_below = true;
+					}
 					break;
 				case LIQUID_FLOWING:
 					// Lower flows cannot flow here
@@ -1161,9 +1166,11 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 								min_dirdist = nb_dirdist - nb_direction;
 							}
 						}
-					} else if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
-						// mark flowing down
-						flowing_down = true;
+					} else {
+						if (cfnb.liquid_alternative_flowing_id == liquid_kind)
+							flowing_down = true;
+						else
+							liquid_below = true;
 					}
 					// Take note of all flows
 					flows[num_flows++] = nb;
@@ -1242,6 +1249,8 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		 */
 		if (flowing_down)
 			new_dirdist = LIQUID_DIRECTION_DOWN;
+		else if (liquid_below)
+			new_dirdist = 0;
 		else if (pt2 == CPT2_DIRECTIONAL_FLOWING &&
 				(new_dirdist > (directed_range * 4)
 						|| (max_node_level < LIQUID_LEVEL_MAX + 1 - directed_range)

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -874,6 +874,9 @@ const static v3s16 liquid_6dirs[6] = {
 	v3s16( 0,-1, 0)
 };
 
+// lower liquids cannot flow here
+const static u8 opposite_6dir[6] = { 5, 3, 4, 1, 2, 99 };
+
 enum NeighborType : u8 {
 	NEIGHBOR_UPPER,
 	NEIGHBOR_SAME_LEVEL,
@@ -1023,6 +1026,23 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			else
 				// non directional source or non liquid node
 				nb_dirdist = 0;
+                        // extract direction from dirdist
+                        // uses liquid_6dirs indices to encode direction, range 0-5
+                        // 0   -> 0: no direction (can't flow up)
+                        // 31  -> 5: flowing down
+                        // 1-4 -> 1-4: flowing directly into neighbor flowing down
+                        // 5-28-> 1-4: direction to closest flowdown, distance is floor((<dirdist>-1)/4)+1
+                        // 29-30 currently unused (TODO: encode flowing down into directional flow)
+                        // a bit ugly, but maximizes encodable distance
+			u8 nb_direction;
+			if (nb_dirdist == LIQUID_DIRECTION_DOWN)
+				nb_direction = 5;
+			else if (nb_dirdist)
+				nb_direction = (nb_dirdist - 1) % 4 + 1;
+			else
+				nb_direction = 0;
+                        // note that opposite_6dir[5]>5
+			bool nb_flows_here = !nb_direction || nb_direction == opposite_6dir[i];
 			if (nt == NEIGHBOR_UPPER && cfnb.floats)
 				floating_node_above = true;
 			switch (cfnb.liquid_type) {
@@ -1059,7 +1079,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 								can_flow_here = true;
 								break;
 							case NEIGHBOR_SAME_LEVEL:
-								can_flow_here = true;
+								can_flow_here = nb_flows_here;
 								break;
 							case NEIGHBOR_LOWER:
 								// cannot happen
@@ -1095,8 +1115,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 								break;
 							case NEIGHBOR_SAME_LEVEL:
 								// exclude falling liquids on the same level, they cannot flow here anyway
-								if (nb_dirdist != LIQUID_DIRECTION_DOWN &&
-										nb_node_level > 0)
+								if (nb_flows_here && nb_node_level > 0)
 									max_level_from_neighbor = nb_node_level - 1;
 								break;
 							case NEIGHBOR_LOWER:

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -1029,7 +1029,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 					if (cfnb.floodable) {
 						airs[num_airs++] = nb;
 						// if the current node is a water source the neighbor
-						// should be enqueded for transformation regardless of whether the
+						// should be enqueuded for transformation regardless of whether the
 						// current node changes or not.
 						if (nb.t != NEIGHBOR_UPPER && liquid_type != LIQUID_NONE)
 							liquid_queue.push_back(npos);

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -1047,13 +1047,32 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 					}
 					break;
 				case LIQUID_SOURCE:
-					// if this node is not (yet) of a liquid type, choose the first liquid type we encounter
-					if (liquid_kind == CONTENT_AIR)
-						liquid_kind = cfnb.liquid_alternative_flowing_id;
-					if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
-						// Do not count bottom source, it will screw things up
-						if(nt != NEIGHBOR_LOWER)
-							num_sources++;
+					// Lower sources can never flow here
+					if (nb.t != NEIGHBOR_LOWER) {
+						bool can_flow_here = false;
+						switch (nb.t) {
+							case NEIGHBOR_UPPER:
+								can_flow_here = true;
+								break;
+							case NEIGHBOR_SAME_LEVEL:
+								can_flow_here = true;
+								break;
+							case NEIGHBOR_LOWER:
+								// cannot happen
+								break;
+						}
+
+						if (can_flow_here) {
+							// if this node is not (yet) of a liquid type,
+							// choose the first liquid type we encounter
+							if (liquid_kind == CONTENT_AIR) {
+								liquid_kind = cfnb.liquid_alternative_flowing_id;
+							}
+							if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
+								// count number of sources that could flow here
+								num_sources++;
+							}
+						}
 					}
 					break;
 				case LIQUID_FLOWING:

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -992,6 +992,8 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 			Collect information about the environment
 		 */
 		int num_sources = 0;
+		NodeNeighbor directional_sources[6]; // surrounding directional sources
+		int num_directional_sources = 0;
 		NodeNeighbor flows[6]; // surrounding flowing liquid nodes
 		int num_flows = 0;
 		NodeNeighbor airs[6]; // surrounding air
@@ -1000,6 +1002,7 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 		bool ignore_node_found = false;
 		bool floating_node_above = false;
 		u8 new_dirdist = 0;
+		u8 min_dirdist = 28;
 		for (u16 i = 0; i < 6; i++) {
 			NeighborType nt = NEIGHBOR_SAME_LEVEL;
 			switch (i) {
@@ -1098,6 +1101,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 								// count number of sources that could flow here
 								// note that liquid type will never change after a source node neighbor has been found
 								num_sources++;
+								// if source is directional it needs to update itself if this node changes
+								if (nb_directional)
+									directional_sources[num_directional_sources++] = nb;
 							}
 						}
 					} else if (cfnb.liquid_alternative_flowing_id == liquid_kind &&
@@ -1139,6 +1145,22 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 						if (cfnb.liquid_alternative_flowing_id == liquid_kind &&
 								max_level_from_neighbor > max_node_level)
 							max_node_level = max_level_from_neighbor;
+						// if directional, pick direction to same level neighbor
+						// of same kind closest to flowdown
+						// note that this may be overridden by flowing_down later
+						if (cfnb.liquid_alternative_flowing_id == liquid_kind &&
+								nb_directional &&
+								!nb_flows_here && nb_dirdist) {
+							if (nb_dirdist == LIQUID_DIRECTION_DOWN) {
+								if (!new_dirdist || new_dirdist > 4) {
+									new_dirdist = i;
+									min_dirdist = 0;
+								}
+							} else if (nb_dirdist <= min_dirdist) {
+								new_dirdist = nb_dirdist - nb_direction + i + 4;
+								min_dirdist = nb_dirdist - nb_direction;
+							}
+						}
 					} else if (cfnb.liquid_alternative_flowing_id == liquid_kind) {
 						// mark flowing down
 						flowing_down = true;
@@ -1341,6 +1363,9 @@ void ServerMap::transformLiquidsLocal(std::map<v3s16, MapBlock*> &modified_block
 				for (u16 i = 0; i < num_airs; i++)
 					if (airs[i].t != NEIGHBOR_UPPER)
 						liquid_queue.push_back(airs[i].p);
+				// make sure all neighboring directional sources update their state
+				for (u16 i = 0; i < num_directional_sources; i++)
+					liquid_queue.push_back(directional_sources[i].p);
 				break;
 			case LIQUID_NONE:
 				// this flow has turned to air; neighboring flows might need to do the same


### PR DESCRIPTION
This is a test PR to solicit feedback concerning the usefulness of the new liquid behavior implemented in this branch, primarily from the Mineclonia community.

It differs from other attempts in that it remains fully within the framework of the current minetest liquid implementation and therefore should be bug-for-bug compatible with current minetest unless the new liquid behavior is explicitly switched on. It adds two new param types, ``directionalflowing`` and ``directionalsource`` with the following changes in behavior

- flowing in a single direction if there is a path within liquid_directed_range to a lower level
- when two or more different liquids meet in a node the strongest flow will displace the other liquids
- a liquid source node that flows down will not spread horizontally
- flowing liquid above a source node of the same kind will not spread horizontally
- rendering is slightly different; older clients will render linear flows without volume, but otherwise work fine

As a special bonus feature directional liquid node tops are rendered 1/16 node lower. But unlike most of the rest of the series, that is just an ugly hack. 

Note that this branch is currently based on a rather old version of minetest 5.9-dev, because that is the version I've been using for some time on my private server and am pretty sure that it has no issues interfering with testing these liquid physics changes.

To test it out

1. check out the branch and build it normally in your environment. (Note that while most of the changes are compiled into the ``minetest`` and ``minetestserver`` executables, ``builtin/game/register.lua`` and ``builtin/settingtypes.txt`` also have relevant changes.) 

2. run it from the build directory or from a suitable installation directory

3. create a new world or take a copy of an existing world (it should be non destructive in the sense that no liquid should flow where it didn't flow before, but there may be bugs)

4. go to the settings and switch the ``force_directional_liquids`` setting

5. run your world

6. on page 3 of the F6 engine profiler you should see some statistics about liquid processing; when creating a new world or loading a world that didn't have directional liquids, there will be a lot of activity on initial loading; it should become stable after a while and only do anything when loading new blocks (e.g. when turning and moving): stopping and reloading the world should have very little activity

7. check out how the water behaves now

8. check out the ``force_liquid_directed_range`` setting that will limit the length of linear flows

9. yell at me that it's crap:-)

The primary goal is to get feedback on whether this is actually useful, what is good, what is bad/missing etc.So please do that. Thank you very much!

Note that this isn't MC liquid even if the results may in some cases look like MC, but it still is very much the minetest liquid system and has different quirks, that might not be fixable within the given framework. The benefit of doing it this way *may* be that it avoids some of the pitfalls that prevented other attempts from getting accepted.